### PR TITLE
feat(agent): support rule count operators

### DIFF
--- a/src/agent/src/notifierQueue.ts
+++ b/src/agent/src/notifierQueue.ts
@@ -26,7 +26,7 @@ export class NotifierQueue extends EventEmitter {
   push(notifs: NotifierAlert) {
     this.#queue.push(notifs);
 
-    if (this.#inProgress++ === 0) {
+    if (this.#inProgress === 0) {
       this.emit(NOTIFIER_QUEUE_EVENTS.DEQUEUE, [...this.#dequeue()]);
 
       return;
@@ -58,6 +58,7 @@ export class NotifierQueue extends EventEmitter {
         break;
       }
 
+      this.#inProgress++;
       yield this.#queue.shift();
     }
   }

--- a/src/agent/src/tasks/asyncTask.ts
+++ b/src/agent/src/tasks/asyncTask.ts
@@ -4,7 +4,7 @@ import { Logger } from "pino";
 
 // Import Internal Dependencies
 import { Rule } from "../rules";
-import { SigynRule } from "../types";
+import { SigynRule } from "../config";
 
 export interface AsyncTaskOptions {
   logger: Logger;

--- a/src/agent/src/utils.ts
+++ b/src/agent/src/utils.ts
@@ -3,8 +3,15 @@ import dayjs, { type Dayjs } from "dayjs";
 import ms from "ms";
 
 // Import Internal Dependencies
-import { getDB } from "./database";
-import { DbRule, SigynRule } from "./types";
+import { DbRule, getDB } from "./database";
+import { SigynRule } from "./config";
+
+// CONSTANTS
+const kOnlyDigitsRegExp = /^\d+$/;
+const kOperatorValue = /^\s*([<>]=?)\s*(\d+)\s*$/;
+
+export type RuleCounterOperator = ">" | ">=" | "<" | "<=";
+export type RuleCounterOperatorValue = [RuleCounterOperator, number];
 
 export function durationToDate(duration: string, operation: "subtract" | "add"): Dayjs {
   const durationMs = ms(duration);
@@ -23,5 +30,36 @@ export function cleanRulesInDb(configRules: SigynRule[]) {
     if (dbRuleConfig === undefined) {
       db.prepare("DELETE FROM rules WHERE name = ?").run(dbRule.name);
     }
+  }
+}
+
+export function ruleCountThresholdOperator(counter: number | string): RuleCounterOperatorValue {
+  if (typeof counter === "number" || kOnlyDigitsRegExp.test(counter)) {
+    return [">=", Number(counter)];
+  }
+
+  const match = counter.replace(/\s/g, "").match(kOperatorValue);
+
+  if (!match || match.length !== 3) {
+    throw new Error("Invalid count threshold format.");
+  }
+
+  const [, operator, value] = match;
+
+  return [operator as RuleCounterOperator, Number(value)];
+}
+
+export function ruleCountMatchOperator(operator: RuleCounterOperator, counter: number, count: number): boolean {
+  switch (operator) {
+    case ">":
+      return counter > count;
+    case ">=":
+      return counter >= count;
+    case "<":
+      return counter < count;
+    case "<=":
+      return counter <= count;
+    default:
+      throw new Error(`Invalid operator: ${operator}`);
   }
 }

--- a/src/agent/test/utils.spec.ts
+++ b/src/agent/test/utils.spec.ts
@@ -2,9 +2,11 @@
 import assert from "node:assert";
 import { describe, it } from "node:test";
 
+// Import Third-party Dependencies
+import dayjs from "dayjs";
+
 // Import Internal Dependencies
 import * as utils from "../src/utils";
-import dayjs from "dayjs";
 
 describe("Utils", () => {
   describe("durationToDate()", () => {
@@ -18,6 +20,107 @@ describe("Utils", () => {
       const date = utils.durationToDate("1y", "subtract");
 
       assert.equal(date.get("y"), dayjs().subtract(1, "y").get("y"));
+    });
+  });
+
+  describe("ruleCountThresholdOperator", () => {
+    const ruleCountThresholdOperatorTests: [number | string, utils.RuleCounterOperatorValue][] = [
+      ["10", [">=", 10]],
+      [10, [">=", 10]],
+      [">= 10", [">=", 10]],
+      [">=10", [">=", 10]],
+      [">=  10", [">=", 10]],
+      [">=  10  ", [">=", 10]],
+      ["  >=  10  ", [">=", 10]],
+      ["> 10", [">", 10]],
+      ["< 10", ["<", 10]],
+      ["<= 10", ["<=", 10]],
+      ["<=10", ["<=", 10]],
+      ["<=  10", ["<=", 10]],
+      ["<=  10  ", ["<=", 10]],
+      ["  <=  10  ", ["<=", 10]],
+      ["<  10  ", ["<", 10]]
+    ];
+
+    for (const [input, expected] of ruleCountThresholdOperatorTests) {
+      it(`should return ${JSON.stringify(expected)} given "${input}"`, () => {
+        const [operator, count] = utils.ruleCountThresholdOperator(input);
+
+        assert.equal(operator, expected[0]);
+        assert.equal(count, expected[1]);
+      });
+    }
+
+    it("should throw if the input is not a valid string", () => {
+      assert.throws(() => {
+        utils.ruleCountThresholdOperator("foo");
+      }, {
+        name: "Error",
+        message: "Invalid count threshold format."
+      });
+    });
+
+    it("should throw if the value is not valid", () => {
+      assert.throws(() => {
+        utils.ruleCountThresholdOperator(">= foo");
+      }, {
+        name: "Error",
+        message: "Invalid count threshold format."
+      });
+    });
+
+    it("should throw if the operator is not valid", () => {
+      assert.throws(() => {
+        utils.ruleCountThresholdOperator("foo 10");
+      }, {
+        name: "Error",
+        message: "Invalid count threshold format."
+      });
+    });
+  });
+
+  describe("ruleCountMatchOperator()", () => {
+    it("should return true if the operator is '>' and the counter is greater than the count", () => {
+      assert.equal(utils.ruleCountMatchOperator(">", 10, 5), true);
+    });
+
+    it("should return true if the operator is '>=' and the counter is greater than or equal to the count", () => {
+      assert.equal(utils.ruleCountMatchOperator(">=", 10, 10), true);
+      assert.equal(utils.ruleCountMatchOperator(">=", 10, 5), true);
+    });
+
+    it("should return true if the operator is '<' and the counter is less than the count", () => {
+      assert.equal(utils.ruleCountMatchOperator("<", 5, 10), true);
+    });
+
+    it("should return true if the operator is '<=' and the counter is less than or equal to the count", () => {
+      assert.equal(utils.ruleCountMatchOperator("<=", 5, 10), true);
+      assert.equal(utils.ruleCountMatchOperator("<=", 10, 10), true);
+    });
+
+    it("should return false if the operator is '>' and the counter is less than the count", () => {
+      assert.equal(utils.ruleCountMatchOperator(">", 5, 10), false);
+    });
+
+    it("should return false if the operator is '>=' and the counter is less than the count", () => {
+      assert.equal(utils.ruleCountMatchOperator(">=", 5, 10), false);
+    });
+
+    it("should return false if the operator is '<' and the counter is greater than the count", () => {
+      assert.equal(utils.ruleCountMatchOperator("<", 10, 5), false);
+    });
+
+    it("should return false if the operator is '<=' and the counter is greater than the count", () => {
+      assert.equal(utils.ruleCountMatchOperator("<=", 10, 5), false);
+    });
+
+    it("should throw if the operator is not valid", () => {
+      assert.throws(() => {
+        utils.ruleCountMatchOperator("foo" as utils.RuleCounterOperator, 10, 5);
+      }, {
+        name: "Error",
+        message: "Invalid operator: foo"
+      });
     });
   });
 });


### PR DESCRIPTION
These changes allows to set a counter operator.
By default, the operator is `>=`
- `"count": 5` (>= 5)
- `"count": "5"` (>= 5)
- `"count": "<5"`
etc

This enables maximum counter (instead of minimum), so we can check for a minimum count of logs for a given interval.

> **Note** I don't see a use case where we need an `equal` (`===`) operator. But it could be added easily.
