### PR TITLE
feat(agent): add support for polling ranges

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1659,6 +1659,25 @@
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
       "dev": true
     },
+    "node_modules/cron-parser": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-4.8.1.tgz",
+      "integrity": "sha512-jbokKWGcyU4gl6jAfX97E1gDpY12DJ1cLJZmoDzaAln/shZ+S3KBFBuA2Q6WeUN4gJf/8klnV1EfvhA2lK5IRQ==",
+      "dependencies": {
+        "luxon": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/croner": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/croner/-/croner-6.0.7.tgz",
+      "integrity": "sha512-k3Xx3Rcclfr60Yx4TmvsF3Yscuiql8LSvYLaphTsaq5Hk8La4Z/udmUANMOTKpgGGroI2F6/XOr9cU9OFkYluQ==",
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
     "node_modules/cross-env": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
@@ -2996,6 +3015,14 @@
       "dev": true,
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.3.0.tgz",
+      "integrity": "sha512-An0UCfG/rSiqtAIiBPO0Y9/zAnHUZxAMiCpTd5h2smgsj7GGmcenvrvww2cqNA8/4A5ZrD1gJpHN2mIHZQF+Mg==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/make-dir": {
@@ -4701,6 +4728,8 @@
       "dependencies": {
         "@myunisoft/loki": "^1.2.0",
         "better-sqlite3": "^8.4.0",
+        "cron-parser": "^4.8.1",
+        "croner": "^6.0.7",
         "dayjs": "^1.11.9",
         "dotenv": "^16.3.1",
         "ms": "^2.1.3",

--- a/src/agent/package.json
+++ b/src/agent/package.json
@@ -33,6 +33,8 @@
   "dependencies": {
     "@myunisoft/loki": "^1.2.0",
     "better-sqlite3": "^8.4.0",
+    "cron-parser": "^4.8.1",
+    "croner": "^6.0.7",
     "dayjs": "^1.11.9",
     "dotenv": "^16.3.1",
     "ms": "^2.1.3",


### PR DESCRIPTION
Note: `croner` is not used but is needed for `toad-sheduler` [cron jobs](https://github.com/kibertoad/toad-scheduler#cron-support)