### PR TITLE
feat: count & range value label rules

### DIFF
--- a/src/agent/src/utils/rules.ts
+++ b/src/agent/src/utils/rules.ts
@@ -6,7 +6,7 @@ import { isCron } from "./cron";
 
 // CONSTANTS
 const kOnlyDigitsRegExp = /^\d+$/;
-const kOperatorValueRegExp = /^\s*([<>]=?)\s*(\d+)\s*$/;
+export const OPERATOR_VALUE_REGEXP = /^\s*([<>]=?)\s*(\d+)\s*$/;
 
 export type RuleOperators = ">" | ">=" | "<" | "<=";
 export type RuleCounterOperatorValue = [RuleOperators, number];
@@ -24,7 +24,7 @@ export function countThresholdOperator(
 
   const match = counter
     .replace(/\s/g, "")
-    .match(kOperatorValueRegExp);
+    .match(OPERATOR_VALUE_REGEXP);
   if (!match || match.length !== 3) {
     throw new Error("Invalid count threshold format.");
   }

--- a/src/agent/test/FT/fixtures/label-count/sigyn.config.json
+++ b/src/agent/test/FT/fixtures/label-count/sigyn.config.json
@@ -12,15 +12,14 @@
   },
   "rules": [
     {
-      "name": "State KO >= 80%",
-      "logql": "{app=\"sigyn\"} |~ `state: (ok|ko)` | regexp `state: (?P<state>ok|ko)`",
+      "name": "Response time >= 500ms",
+      "logql": "{app=\"sigyn\"} |~ `statusCode: [0-9]+` | regexp `((?P<responseTime>\\d+\\.\\d+)ms)`",
       "polling": "200ms",
       "alert": {
         "on": {
-          "label": "state",
-          "value": "ko",
-          "percentThreshold": 80,
-          "minimumLabelCount": 10
+          "label": "responseTime",
+          "value": "> 500",
+          "count": 1
         },
         "template": {
           "title": "Alert"

--- a/src/agent/test/FT/fixtures/label-range-value/sigyn.config.json
+++ b/src/agent/test/FT/fixtures/label-range-value/sigyn.config.json
@@ -12,13 +12,13 @@
   },
   "rules": [
     {
-      "name": "State KO >= 80%",
-      "logql": "{app=\"sigyn\"} |~ `state: (ok|ko)` | regexp `state: (?P<state>ok|ko)`",
+      "name": "Response time >= 1000ms",
+      "logql": "{app=\"sigyn\"} |~ `statusCode: [0-9]+` | regexp `((?P<responseTime>\\d+\\.\\d+)ms)`",
       "polling": "200ms",
       "alert": {
         "on": {
-          "label": "state",
-          "value": "ko",
+          "label": "responseTime",
+          "value": "> 1000",
           "percentThreshold": 80,
           "minimumLabelCount": 10
         },

--- a/src/config/README.md
+++ b/src/config/README.md
@@ -96,7 +96,7 @@ The **Sigyn** configuration object consists of theses properties: `loki`, `templ
         "on": {
           "label": "state",
           "value": "ko",
-          "thresholdPercent": 80,
+          "percentThreshold": 80,
           "interval": "5d"
         },
         "template": {
@@ -187,18 +187,20 @@ The `defaultSeverity` defines the rule alert severities when not specified. Seve
   - An object specifying when the alert should trigger.
   - It must have the following properties:
 
-  | Property           | Type                 | Required | Description |
-  |--------------------|----------------------|----------|-------------|
-  | `count`            | `number` or `string` | The count threshold of log that must triggers an alert **or** the minimum count of logs to triggers a **label based** alert. You can use a range string i.e. `<= 5`, `> 6`. For **label based** alert, this property **MUST** be a valid number i.e `900` or `"900"` |
-  | `interval`         | `string`             | The time interval for the alerting condition. |
-  | `label`            | `string`             | The label key to check. |
-  | `value`            | `string`             | The label value to check. |
-  | `thresholdPercent` | `number`             | The threshold percent of label value. |
+  | Property            | Type                 | Required | Description |
+  |---------------------|----------------------|----------|-------------|
+  | `count`             | `number` or `string` | The count threshold of log or label that must triggers an alert. You can use a range string i.e. `<= 5`, `> 6`. For **label based** alert, this property **MUST** be a valid number i.e `900` or `"900"` |
+  | `interval`          | `string`             | The time interval for the alerting condition. |
+  | `label`             | `string`             | The label key to check. |
+  | `value`             | `string`             | The label value to check. |
+  | `percentThreshold`  | `number`             | The percent threshold of label value. |
+  | `minimumLabelCount` | `number`             | The minimum count of label to compare percent threshold. |
 
   > [!NOTE]
   > There are 2 sorts of alert: **basic** and **label based**
   > For **basic** alert, both `count` and `interval` are **required**, other properties **must** be omitted.
-  > For **label based** alert, `label`, `value` and `thresholdPercent` are **required** plus at least one of `count` or `interval` which defines the minimum logs to be fetched to have a revelant alert.
+  > For **label based** alert, `label`, `value` are **required** plus at least one of `minimumLabelCount` or `interval` which defines the minimum logs to be fetched to have a revelant alert when `percentThreshold` is set, or `count` which works the same as basic alerting.
+  > `minimumLabelCount` and/or `interval` are optional when rule is based on `count` label.
 
 - `rules.alert.template` (Object or String, Required):
   - Can be an object representing the notification template or a string refering to a root template.

--- a/src/config/src/schemas/rules.json
+++ b/src/config/src/schemas/rules.json
@@ -86,33 +86,104 @@
                 "title": "The label value to watch",
                 "type": "string"
               },
-              "thresholdPercent": {
+              "percentThreshold": {
                 "title": "The maximum percent of the given label value to trigger an alert",
+                "type": "integer"
+              },
+              "minimumLabelCount": {
+                "title": "The minimum number of labels to compare with the percentThreshold",
                 "type": "integer"
               }
             },
-            "anyOf": [
+            "allOf": [
               {
-                "required": [
-                  "count",
-                  "interval"
-                ]
+                "if": {
+                  "required": [
+                    "label",
+                    "percentThreshold"
+                  ]
+                },
+                "then": {
+                  "required": [
+                    "value"
+                  ],
+                  "anyOf": [
+                    {
+                      "required": [
+                          "minimumLabelCount"
+                        ]
+                    },
+                    {
+                      "required": [
+                          "interval"
+                        ]
+                    }
+                  ],
+                  "not": {
+                    "required": [
+                      "count"
+                    ]
+                  }
+                },
+                "else": {
+                  "dependentRequired": {
+                    "label": [
+                      "count"
+                    ]
+                  }
+                }
               },
               {
-                "required": [
-                  "label",
-                  "value",
-                  "thresholdPercent",
-                  "count"
-                ]
+                "if": {
+                  "required": [
+                    "label",
+                    "count"
+                  ]
+                },
+                "then": {
+                  "required": [
+                    "value"
+                  ],
+                  "not": {
+                    "required": [
+                      "percentThreshold"
+                    ]
+                  }
+                },
+                "else": {
+                  "dependentRequired": {
+                    "label": [
+                      "percentThreshold"
+                    ]
+                  }
+                }
               },
               {
-                "required": [
-                  "label",
-                  "value",
-                  "thresholdPercent",
-                  "interval"
-                ]
+                "if": {
+                  "not": {
+                    "required": [
+                      "label"
+                    ]
+                  }
+                },
+                "then": {
+                  "required": [
+                    "count",
+                    "interval"
+                  ],
+                  "not": {
+                    "required": [
+                      "percentThreshold",
+                      "value",
+                      "minimumLabelCount"
+                    ]
+                  }
+                },
+                "else": {
+                  "required": [
+                    "value"
+                  ]
+                }
               }
             ],
             "additionalProperties": false

--- a/src/config/src/types.ts
+++ b/src/config/src/types.ts
@@ -62,7 +62,8 @@ export interface SigynAlert {
     interval?: string;
     label?: string;
     value?: string;
-    thresholdPercent?: number;
+    percentThreshold?: number;
+    minimumLabelCount?: number;
   },
   template: string | SigynAlertTemplate;
   severity: Extract<AlertSeverity, "critical" | "error" | "warning" | "information">;
@@ -78,7 +79,8 @@ export interface PartialSigynAlert {
     interval?: string;
     label?: string;
     value?: string;
-    thresholdPercent?: number;
+    percentThreshold?: number;
+    minimumLabelCount?: number;
   },
   template: string | SigynAlertTemplate;
   severity?: AlertSeverity;

--- a/src/config/src/validate.ts
+++ b/src/config/src/validate.ts
@@ -1,5 +1,5 @@
 // Import Third-party Dependencies
-import Ajv, { ErrorObject } from "ajv";
+import Ajv, { ErrorObject } from "ajv/dist/2020";
 import ajvKeywords from "ajv-keywords";
 
 // Import Internal Dependencies


### PR DESCRIPTION
- `thresholdPercent` has been renamed to `percentThreshold`
- `count` when rule is label based now works same as basic rule instead of representing the minimum count of label
- `minimumLabelCount` replace the previous `count` behavior for label based rules
- label `value` now can handle range value (useful for responseTime, for example)
- JSON Schema improved using `if-else-then`