### PR TITLE
chore(ci): update paths to make ci run on dependencies updates

### DIFF
--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
     paths:
       - "src/agent/**"
-      - "!src/agent/README.md"
+      - "!src/agent/**/*.md"
 
 permissions:
   contents: read

--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -6,6 +6,7 @@ on:
     
   pull_request:
     paths:
+      - "package-lock.json"
       - "src/agent/**"
       - "!src/agent/**/*.md"
 

--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -3,13 +3,11 @@ name: Sigyn Agent
 on:
   push:
     branches: [main]
-    paths:
-      - src/agent/src/**
-      - src/agent/test/**
+    
   pull_request:
     paths:
-      - src/agent/src/**
-      - src/agent/test/**
+      - "src/agent/**"
+      - "!src/agent/README.md"
 
 permissions:
   contents: read

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     paths:
+      - "package-lock.json"
       - "src/config/**"
       - "!src/config/**/*.md"
 

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -3,13 +3,10 @@ name: Sigyn Config
 on:
   push:
     branches: [main]
-    paths:
-      - src/config/src/**
-      - src/config/test/**
   pull_request:
     paths:
-      - src/config/src/**
-      - src/config/test/**
+      - "src/config/**"
+      - "!src/config/README.md"
 
 permissions:
   contents: read

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     paths:
       - "src/config/**"
-      - "!src/config/README.md"
+      - "!src/config/**/*.md"
 
 permissions:
   contents: read

--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -3,13 +3,10 @@ name: Sigyn Discord
 on:
   push:
     branches: [main]
-    paths:
-      - src/discord/src/**
-      - src/discord/test/**
   pull_request:
     paths:
-      - src/discord/src/**
-      - src/discord/test/**
+      - "src/discord/**"
+      - "!src/discord/README.md"
 
 permissions:
   contents: read

--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     paths:
       - "src/discord/**"
-      - "!src/discord/README.md"
+      - "!src/discord/**/*.md"
 
 permissions:
   contents: read

--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     paths:
+      - "package-lock.json"
       - "src/discord/**"
       - "!src/discord/**/*.md"
 

--- a/.github/workflows/logql.yml
+++ b/.github/workflows/logql.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     paths:
+      - "package-lock.json"
       - "src/logql/**"
       - "!src/logql/**/*.md"
 

--- a/.github/workflows/logql.yml
+++ b/.github/workflows/logql.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     paths:
       - "src/logql/**"
-      - "!src/logql/README.md"
+      - "!src/logql/**/*.md"
 
 permissions:
   contents: read

--- a/.github/workflows/logql.yml
+++ b/.github/workflows/logql.yml
@@ -3,13 +3,10 @@ name: Sigyn LogQL
 on:
   push:
     branches: [main]
-    paths:
-      - src/logql/src/**
-      - src/logql/test/**
   pull_request:
     paths:
-      - src/logql/src/**
-      - src/logql/test/**
+      - "src/logql/**"
+      - "!src/logql/README.md"
 
 permissions:
   contents: read

--- a/.github/workflows/morphix.yml
+++ b/.github/workflows/morphix.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     paths:
       - "src/morphix/**"
-      - "!src/morphix/README.md"
+      - "!src/morphix/**/*.md"
 
 permissions:
   contents: read

--- a/.github/workflows/morphix.yml
+++ b/.github/workflows/morphix.yml
@@ -3,13 +3,10 @@ name: Morphix
 on:
   push:
     branches: [main]
-    paths:
-      - src/morphix/src/**
-      - src/morphix/test/**
   pull_request:
     paths:
-      - src/morphix/src/**
-      - src/morphix/test/**
+      - "src/morphix/**"
+      - "!src/morphix/README.md"
 
 permissions:
   contents: read

--- a/.github/workflows/morphix.yml
+++ b/.github/workflows/morphix.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     paths:
+      - "package-lock.json"
       - "src/morphix/**"
       - "!src/morphix/**/*.md"
 

--- a/.github/workflows/notifiers.yml
+++ b/.github/workflows/notifiers.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     paths:
+      - "package-lock.json"
       - "src/notifiers/**"
       - "!src/notifiers/**/*.md"
 

--- a/.github/workflows/notifiers.yml
+++ b/.github/workflows/notifiers.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     paths:
       - "src/notifiers/**"
-      - "!src/notifiers/README.md"
+      - "!src/notifiers/**/*.md"
 
 permissions:
   contents: read

--- a/.github/workflows/notifiers.yml
+++ b/.github/workflows/notifiers.yml
@@ -3,13 +3,10 @@ name: Notifiers
 on:
   push:
     branches: [main]
-    paths:
-      - src/notifiers/src/**
-      - src/notifiers/test/**
   pull_request:
     paths:
-      - src/notifiers/src/**
-      - src/notifiers/test/**
+      - "src/notifiers/**"
+      - "!src/notifiers/README.md"
 
 permissions:
   contents: read

--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     paths:
+      - "package-lock.json"
       - "src/slack/**"
       - "!src/slack/**/*.md"
 

--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -3,13 +3,10 @@ name: Sigyn Slack
 on:
   push:
     branches: [main]
-    paths:
-      - src/slack/src/**
-      - src/slack/test/**
   pull_request:
     paths:
-      - src/slack/src/**
-      - src/slack/test/**
+      - "src/slack/**"
+      - "!src/slack/README.md"
 
 permissions:
   contents: read

--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     paths:
       - "src/slack/**"
-      - "!src/slack/README.md"
+      - "!src/slack/**/*.md"
 
 permissions:
   contents: read

--- a/.github/workflows/teams.yml
+++ b/.github/workflows/teams.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     paths:
       - "src/teams/**"
-      - "!src/teams/README.md"
+      - "!src/teams/**/*.md"
 
 permissions:
   contents: read

--- a/.github/workflows/teams.yml
+++ b/.github/workflows/teams.yml
@@ -3,13 +3,10 @@ name: Sigyn Teams
 on:
   push:
     branches: [main]
-    paths:
-      - src/teams/src/**
-      - src/teams/test/**
   pull_request:
     paths:
-      - src/teams/src/**
-      - src/teams/test/**
+      - "src/teams/**"
+      - "!src/teams/README.md"
 
 permissions:
   contents: read

--- a/.github/workflows/teams.yml
+++ b/.github/workflows/teams.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     paths:
+      - "package-lock.json"
       - "src/teams/**"
       - "!src/teams/**/*.md"
 


### PR DESCRIPTION
The idea is to run tests when DependaBot make PRs: https://github.com/MyUnisoft/sigyn/pull/146 -> no tests here.